### PR TITLE
Copy travis builds over from lokacore.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,59 @@ branches:
     - trying
     - master
 
+matrix:
+  fast_finish: true
+  allow_failures:
+    # Can't compile spirv_cross for WASM currently... maybe via emscripten?  Needs more C++ headers...
+    # "src/vendor/SPIRV-Cross/spirv_common.hpp:22:10: fatal error: 'algorithm' file not found"
+    - env: TARGET=wasm32-unknown-unknown
+    - env: TARGET=wasm32-wasi
+
+    # X11 2.18.1 doesn't like to cross compile for *-unknown-linux-gnueabihf
+    # "thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: CrossCompilation', src/libcore/result.rs:999:5"
+    - env: TARGET=arm-unknown-linux-gnueabihf
+    - env: TARGET=armv7-unknown-linux-gnueabihf
+    - env: TARGET=thumbv7neon-unknown-linux-gnueabihf
+
+    # Some versions of OS X can't target metal in the simulator.  See https://stackoverflow.com/a/56496197
+    # "xcrun: error: unable to find utility "metal", not a developer tool or in PATH"
+    # "thread 'main' panicked at 'shader compilation failed', /Users/travis/.cargo/registry/src/github.com-1ecc6299db9ec823/gfx-backend-metal-0.2.3/build.rs:69:13"
+    - env: TARGET=x86_64-apple-ios FLAGS="--features simulator-metal"
+
+  include:
+    - { os: linux, rust: stable,  env: CLIPPY=true }
+
+    - { os: linux, rust: stable,  env: FLAGS=--release }
+    - { os: osx,   rust: stable,  env: FLAGS=--release }
+
+    #- { os: linux, rust: stable,  env: TARGET=wasm32-unknown-unknown }
+    #- { os: linux, rust: stable,  env: TARGET=wasm32-wasi }
+    - { os: linux, rust: stable,  env: TARGET=aarch64-linux-android }
+    - { os: linux, rust: stable,  env: TARGET=armv7-linux-androideabi }
+    - { os: linux, rust: stable,  env: TARGET=i686-linux-android }
+    - { os: linux, rust: stable,  env: TARGET=x86_64-linux-android }
+    #- { os: linux, rust: stable,  env: TARGET=arm-unknown-linux-gnueabihf }
+    #- { os: linux, rust: stable,  env: TARGET=armv7-unknown-linux-gnueabihf }
+    #- { os: linux, rust: stable,  env: TARGET=thumbv7neon-unknown-linux-gnueabihf }
+
+    - { os: osx,   rust: stable,  env: TARGET=aarch64-apple-ios }
+    - { os: osx,   rust: stable,  env: TARGET=armv7-apple-ios }
+    - { os: osx,   rust: stable,  env: TARGET=armv7s-apple-ios }
+    - { os: osx,   rust: stable,  env: TARGET=i386-apple-ios }
+    - { os: osx,   rust: stable,  env: TARGET=x86_64-apple-ios }
+    #- { os: osx,   rust: stable,  env: TARGET=x86_64-apple-ios FLAGS="--features simulator-metal" }
+
 script:
-  - cargo build
-  - cargo test # this builds the examples as well
+  - pushd scripts
+  - chmod +x ./travis.sh
+  - ./travis.sh
+  - popd
+
+# Configured so we cache cargo-web for WASM unit testing, otherwise it takes forever (13+ minutes) to compile.
+# See also https://levans.fr/rust_travis_cache.html
+cache:
+  directories:
+    - $TRAVIS_HOME/.cargo/
+    - $TRAVIS_HOME/.rustup/
+before_cache:
+  - rm -rf "$TRAVIS_HOME/.cargo/registry/src"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,15 +13,24 @@ license = "0BSD"
 gfx-hal = { version = "0.2", default-features = false }
 gfx-backend-gl = { version = "0.2", default-features = true }
 
-[target.'cfg(any(windows, unix))'.dependencies.gfx-backend-vulkan]
+[target.'cfg(any(windows, all(unix, not(target_os = "ios"))))'.dependencies.gfx-backend-vulkan]
 version = "0.2"
 default-features = false
 [target.'cfg(windows)'.dependencies.gfx-backend-dx12]
 version = "0.2"
-default-features = false
-[target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies.gfx-backend-metal]
+[target.'cfg(any(target_os = "macos", all(target_arch = "aarch64", target_os = "ios")))'.dependencies.gfx-backend-metal]
 version = "0.2"
 default-features = false
+[target.'cfg(all(target_arch = "x86_64", target_os = "ios"))'.dependencies.gfx-backend-metal]
+version = "0.2"
+default-features = false
+optional = true
+
+[features]
+default = []
+# If your host build machine(s) are OS X 10.15 or higher, you can use gfx-backend-metal in the iOS simulator via this feature.
+# Travis is on OS X 10.13, so this is almost completely untested.
+simulator-metal = ["gfx-backend-metal"]
 
 [badges]
 appveyor = { repository = "Lokathor/gfx-backend-runtime" }

--- a/scripts/generic-cross/.cargo/config
+++ b/scripts/generic-cross/.cargo/config
@@ -1,0 +1,16 @@
+# Don't generate CPU mismatch warnings when cross-compiling
+
+[target.arm-unknown-linux-gnueabihf]
+ar     = "arm-linux-gnueabihf-ar"
+linker = "arm-linux-gnueabihf-gcc"
+rustflags = ["-C","target-cpu=generic"]
+
+[target.armv7-unknown-linux-gnueabihf]
+ar     = "arm-linux-gnueabihf-ar"
+linker = "arm-linux-gnueabihf-gcc"
+rustflags = ["-C","target-cpu=generic"]
+
+[target.thumbv7neon-unknown-linux-gnueabihf]
+ar     = "arm-linux-gnueabihf-ar"
+linker = "arm-linux-gnueabihf-gcc"
+rustflags = ["-C","target-cpu=generic"]

--- a/scripts/linux-android/.cargo/config
+++ b/scripts/linux-android/.cargo/config
@@ -1,0 +1,21 @@
+# Android ar/linker/flags config for when building on linux.
+
+[target.aarch64-linux-android]
+ar = "aarch64-linux-android-ar"
+linker = "aarch64-linux-android21-clang"
+rustflags = ["-C","target-cpu=generic"]
+
+[target.armv7-linux-androideabi]
+ar = "arm-linux-androideabi-ar"
+linker = "armv7a-linux-androideabi21-clang"
+rustflags = ["-C","target-cpu=generic"]
+
+[target.i686-linux-android]
+ar = "i686-linux-android-ar"
+linker = "i686-linux-android21-clang"
+rustflags = ["-C","target-cpu=generic"]
+
+[target.x86_64-linux-android]
+ar = "x86_64-linux-android-ar"
+linker = "x86_64-linux-android21-clang"
+rustflags = ["-C","target-cpu=generic"]

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+set -e
+if [[ "$ANDROID_SDK_VERSION" == "" ]]; then export ANDROID_SDK_VERSION=21; fi
+if [[ "$RUST_BACKTRACE"      == "" ]]; then export RUST_BACKTRACE=1;       fi # In case of panicing build scripts or tests
+
+
+if [[ "$CLIPPY" != "" ]]; then
+  rustup component add clippy
+  cargo clippy
+fi
+
+if [[ "$TARGET" != "" ]]; then rustup target install $TARGET; fi
+
+if [[ "$TARGET" == "wasm32-"* && "$TARGET" != "wasm32-wasi" ]]; then
+  cargo-web --version || cargo install cargo-web
+  cargo web build $FLAGS --target=$TARGET
+  cargo web test  $FLAGS --target=$TARGET
+
+elif [[ "$TARGET" == *"-linux-android"* ]]; then
+  # Modern Java has trouble with sdkmanager: https://stackoverflow.com/questions/46402772/failed-to-install-android-sdk-java-lang-noclassdeffounderror-javax-xml-bind-a
+  export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/jre/
+
+  # Suppress warnings
+  mkdir ~/.android
+  touch ~/.android/repositories.cfg
+
+  # See https://developer.android.com/studio#command-tools for latest version
+  curl -L https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip -o ~/android-sdk.zip
+  unzip -q ~/android-sdk.zip -d ~/android-sdk
+  export PATH="${HOME}/android-sdk/tools/bin:$PATH"                                             # sdkmanager etc.
+  export PATH="${HOME}/android-sdk/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH"  # Cross compilers
+  yes | sdkmanager --licenses >/dev/null 2>/dev/null
+
+  #sdkmanager --list
+  sdkmanager "tools"                        | tr '\r' '\n' | grep -v %
+  sdkmanager "platform-tools"               | tr '\r' '\n' | grep -v %
+  sdkmanager "build-tools;27.0.3"           | tr '\r' '\n' | grep -v %
+  sdkmanager "platforms;android-21"         | tr '\r' '\n' | grep -v %
+  sdkmanager "ndk-bundle"                   | tr '\r' '\n' | grep -v %
+
+  # cc crate isn't cool enough to use .cargo/config 's linker... although to be fair it's also trying to compile code...
+  export COMPILER_PREFIX=$(echo $TARGET | sed s/armv7/armv7a/)
+  export ETC_PREFIX=$(echo $TARGET | sed s/armv7/arm/)
+  export AR=${ETC_PREFIX}-ar
+  export AS=${ETC_PREFIX}-as
+  export CC=${COMPILER_PREFIX}${ANDROID_SDK_VERSION}-clang
+  export CXX=${COMPILER_PREFIX}${ANDROID_SDK_VERSION}-clang++
+  export LD=${ETC_PREFIX}-ld
+
+  pushd linux-android
+    cargo build --target=$TARGET
+    # Don't test, can't run android emulators successfully on travis currently
+  popd
+
+elif [[ "$TARGET" == *"-apple-ios" || "$TARGET" == "wasm32-wasi" ]]; then
+  cargo build --target=$TARGET $FLAGS
+  # Don't test
+  #   iOS simulator setup/teardown is complicated
+  #   cargo-web doesn't support wasm32-wasi yet, nor can wasm-pack test specify a target
+
+elif [[ "$TARGET" == *"-unknown-linux-gnueabihf" ]]; then
+  sudo apt-get update
+  sudo apt-get install -y gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf
+  pushd generic-cross
+    cargo build --target=$TARGET $FLAGS
+    # Don't test
+  popd
+
+elif [[ "$TARGET" != "" ]]; then
+  pushd generic-cross
+    cargo build --target=$TARGET $FLAGS
+    cargo test  --target=$TARGET $FLAGS
+  popd
+
+else
+  # Push nothing, target host CPU architecture
+  cargo build $FLAGS
+  cargo test  $FLAGS
+
+fi

--- a/scripts/windows-android/.cargo/config
+++ b/scripts/windows-android/.cargo/config
@@ -1,0 +1,21 @@
+# Android ar/linker/flags config for when building on windows.
+
+[target.aarch64-linux-android]
+ar = "aarch64-linux-android-ar.cmd"
+linker = "aarch64-linux-android21-clang.cmd"
+rustflags = ["-C","target-cpu=generic"]
+
+[target.armv7-linux-androideabi]
+ar = "armv7a-linux-androideabi-ar.cmd"
+linker = "armv7a-linux-androideabi21-clang.cmd"
+rustflags = ["-C","target-cpu=generic"]
+
+[target.i686-linux-android]
+ar = "i686-linux-android-ar.cmd"
+linker = "i686-linux-android21-clang.cmd"
+rustflags = ["-C","target-cpu=generic"]
+
+[target.x86_64-linux-android]
+ar = "x86_64-linux-android-ar.cmd"
+linker = "x86_64-linux-android21-clang.cmd"
+rustflags = ["-C","target-cpu=generic"]


### PR DESCRIPTION
Differences:
- Target stable instead of 1.36.0.
- Trim non-stable targets entirely.

Kept scripts/generic-cross and rustflags settings, just in case.

## NOTE

For some reason I can't get travis-ci.org to see my fork for testing like I've done in the past... this PR will be the first actual test of these copied rules.  They probably maybe work!

## Issues

- [x] Cannot compile spirv_cross for wasm (missing `<algorithm>` among other things...)
- [x] Missing C++ cross compilers for `*-android*`
- [x] Missing C++ cross compilers for `*-linux-gnueabihf`
- [x] iOS tries to use `gfx-backend-vulkan` which tries to use `x11`.  Just use gfx-backend-metal instead...?  Does that even exist?